### PR TITLE
[Packaging] Add experimental Flatpak support

### DIFF
--- a/org.hjdskes.gcolor3.json
+++ b/org.hjdskes.gcolor3.json
@@ -16,7 +16,7 @@
         "--socket=x11",
         "--socket=wayland",
 
-        "--filesystem=xdg-config/gcolor3/config.ini:ro"
+        "--filesystem=xdg-config/gcolor3/config.ini:rw"
     ],
     
     "build-options": {

--- a/org.hjdskes.gcolor3.json
+++ b/org.hjdskes.gcolor3.json
@@ -1,5 +1,5 @@
 {
-    "app-id": "org.unia.gcolor3",
+    "app-id": "org.hjdskes.gcolor3",
 
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.26",
@@ -36,10 +36,9 @@
             "name": "gcolor3",
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/Hjdskes/gcolor3.git",
-                    "branch": "v2.2",
-                    "commit": "890d82aba1e08b880dc075c4923ec3c52f99e203"
+                    "type": "archive",
+                    "url": "https://github.com/Hjdskes/gcolor3/archive/v2.2.tar.gz",
+                    "sha256": "a3f67108ef7524b424b774b4b68332e45371703f61d659ce7ca1da47c7fb5590"
                 }
             ]
         }

--- a/org.unia.gcolor3.json
+++ b/org.unia.gcolor3.json
@@ -1,0 +1,47 @@
+{
+    "app-id": "org.unia.gcolor3",
+
+    "runtime": "org.gnome.Platform",
+    "runtime-version": "3.26",
+    "sdk": "org.gnome.Sdk",
+
+    "command": "gcolor3",
+
+    "rename-icon": "gcolor3",
+    "rename-desktop-file": "gcolor3.desktop",
+    "rename-appdata-file": "gcolor3.appdata.xml",
+
+    "finish-args": [
+        "--share=ipc",
+        "--socket=x11",
+        "--socket=wayland",
+
+        "--filesystem=xdg-config/gcolor3/config.ini:ro"
+    ],
+    
+    "build-options": {
+        "cflags": "-O2 -g"
+    },
+    
+    "cleanup": [
+        "*.la",
+        "*.a",
+        "/include",
+        "/lib/pkgconfig",
+        "/share/man"
+    ],
+    
+    "modules": [
+        {
+            "name": "gcolor3",
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/Hjdskes/gcolor3.git",
+                    "branch": "v2.2",
+                    "commit": "890d82aba1e08b880dc075c4923ec3c52f99e203"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
This pr adds an initial flatpak manifest and should close #71. I would recommend changing the `gcolor3.svg`, `gcolor3.desktop`, & `gcolor3.appdata.xml` file from `gcolor.*` to `org.unia.gcolor3.*` since flatpak automatically looks for those files based on the application id. It would also be needed since the the shell will look for org.unia.gcolor3.svg but your application will look for gcolor3.svg in the About modal window.

Things seem to be working and I added `--socket=wayland` but obviously because of #67 it won't work 100% on wayland. Didn't try x11 since I use wayland.

## Build
```
flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
flatpak --user install flathub org.gnome.Platform//3.26
flatpak --user install flathub org.gnome.Sdk//3.26

flatpak-builder --force-clean --repo=repo gcolor3 org.unia.gcolor3.json
flatpak --user remote-add --no-gpg-verify --if-not-exists gcolor3 repo
flatpak --user install gcolor3 org.unia.gcolor3
flatpak --user update org.unia.gcolor3

flatpak run org.unia.gcolor3
```

## Future
If you plan on following-up on #59 then you will need to add the following to `finish-args`:
```
"--env=DCONF_USER_CONFIG_DIR=.config/dconf",
"--filesystem=xdg-run/dconf",
"--filesystem=~/.config/dconf:ro",
"--talk-name=ca.desrt.dconf",
```