### PR TITLE
Fix for Picking anywhere gives #FFFFFF #73

### DIFF
--- a/src/gcolor3-color-selection.c
+++ b/src/gcolor3-color-selection.c
@@ -1704,9 +1704,9 @@ grab_color_at_pointer (GdkScreen *screen,
   color.blue = pixels[2] * 0x101;
   g_object_unref (pixbuf);
 
-  priv->color[COLORSEL_RED] = color.red;
-  priv->color[COLORSEL_GREEN] = color.green;
-  priv->color[COLORSEL_BLUE] = color.blue;
+  priv->color[COLORSEL_RED] =  SCALE(color.red);
+  priv->color[COLORSEL_GREEN] =  SCALE(color.green);
+  priv->color[COLORSEL_BLUE] =  SCALE(color.blue);
 
   gtk_rgb_to_hsv (priv->color[COLORSEL_RED],
                   priv->color[COLORSEL_GREEN],


### PR DESCRIPTION
Fix for Picking anywhere gives #FFFFFF #73.

I am no C programmer, but this is change makes it work for me on Ubuntu x64 17.10. If this was working on another system, then the change may break that environment. In which case we need some check to see what color format we received back from the eyedropper act appropriately.