### PR TITLE
Remove window-global key handlers

### DIFF
--- a/data/color-row.ui
+++ b/data/color-row.ui
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="Gcolor3ColorRow" parent="GtkListBoxRow">
+    <property name="visible">True</property>
+    <property name="can_focus">True</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">12</property>
+        <property name="spacing">12</property>
+        <child>
+          <object class="GtkImage" id="image">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="icon_name">image-missing</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="valign">baseline</property>
+            <property name="label">Hex</property>
+            <property name="justify">center</property>
+            <property name="single_line_mode">True</property>
+            <property name="track_visited_links">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="entry">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="tooltip_text" translatable="yes">Click to change the color's name</property>
+            <property name="text" translatable="yes">Name</property>
+            <property name="caps_lock_warning">False</property>
+            <signal name="activate" handler="gcolor3_color_row_entry_activated" object="Gcolor3ColorRow" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">False</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
+            <property name="tooltip_text" translatable="yes">Delete this color</property>
+            <property name="relief">none</property>
+            <property name="always_show_image">True</property>
+            <signal name="clicked" handler="gcolor3_color_row_delete_button_clicked" object="Gcolor3ColorRow" swapped="no"/>
+            <child>
+              <object class="GtkImage" id="image_delete">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">edit-delete-symbolic</property>
+              </object>
+            </child>
+            <style>
+              <class name="circular"/>
+              <class name="image-button"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/color-row.ui
+++ b/data/color-row.ui
@@ -55,31 +55,60 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButton">
+          <object class="GtkButtonBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="receives_default">False</property>
-            <property name="tooltip_text" translatable="yes">Delete this color</property>
-            <property name="relief">none</property>
-            <property name="always_show_image">True</property>
-            <signal name="clicked" handler="gcolor3_color_row_delete_button_clicked" object="Gcolor3ColorRow" swapped="no"/>
+            <property name="homogeneous">True</property>
+            <property name="layout_style">expand</property>
             <child>
-              <object class="GtkImage" id="image_delete">
+              <object class="GtkButton">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="icon_name">edit-delete-symbolic</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="tooltip_text" translatable="yes">Copy this color's hex value to the clipboard</property>
+                <property name="always_show_image">True</property>
+                <signal name="clicked" handler="gcolor3_color_row_copy_button_clicked" object="Gcolor3ColorRow" swapped="no"/>
+                <child>
+                  <object class="GtkImage" id="image_copy">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">edit-copy-symbolic</property>
+                  </object>
+                </child>
               </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
             </child>
-            <style>
-              <class name="circular"/>
-              <class name="image-button"/>
-            </style>
+            <child>
+              <object class="GtkButton">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="tooltip_text" translatable="yes">Delete this color</property>
+                <property name="always_show_image">True</property>
+                <signal name="clicked" handler="gcolor3_color_row_delete_button_clicked" object="Gcolor3ColorRow" swapped="no"/>
+                <child>
+                  <object class="GtkImage" id="image_delete">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">edit-delete-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">False</property>
-            <property name="pack_type">end</property>
-            <property name="position">3</property>
+            <property name="position">4</property>
           </packing>
         </child>
       </object>

--- a/data/gcolor3.gresource.xml
+++ b/data/gcolor3.gresource.xml
@@ -3,6 +3,7 @@
   <gresource prefix="/nl/hjdskes/gcolor3/">
     <!-- Using this alias, GtkApplication will automatically pick it up for us. -->
     <file alias="gtk/menus.ui" preprocess="xml-stripblanks">menus.ui</file>
+    <file alias="color-row.ui" preprocess="xml-stripblanks">color-row.ui</file>
     <file alias="window.ui" preprocess="xml-stripblanks">window.ui</file>
   </gresource>
 </gresources>

--- a/data/window.ui
+++ b/data/window.ui
@@ -102,9 +102,9 @@
             <property name="can_default">True</property>
             <property name="has_default">True</property>
             <property name="receives_default">False</property>
-            <property name="action_name">win.save</property>
             <property name="image">button_save_image</property>
             <property name="always_show_image">True</property>
+            <signal name="clicked" handler="gcolor3_window_save_button_clicked" object="Gcolor3Window" swapped="no"/>
           </object>
           <packing>
             <property name="pack_type">end</property>
@@ -117,6 +117,7 @@
             <property name="can_focus">True</property>
             <property name="activates_default">True</property>
             <property name="placeholder_text" translatable="yes">Color name...</property>
+            <signal name="key-release-event" handler="gcolor3_window_picker_page_key_handler" object="Gcolor3Window" swapped="no"/>
           </object>
           <packing>
             <property name="pack_type">end</property>

--- a/data/window.ui
+++ b/data/window.ui
@@ -2,25 +2,10 @@
 <!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
-  <object class="GtkImage" id="button_delete_image">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">edit-delete-symbolic</property>
-  </object>
   <object class="GtkImage" id="button_save_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="icon_name">document-save-symbolic</property>
-  </object>
-  <object class="GtkListStore" id="liststore">
-    <columns>
-      <!-- column-name pixbuf -->
-      <column type="GdkPixbuf"/>
-      <!-- column-name column1 -->
-      <column type="gchararray"/>
-      <!-- column-name text -->
-      <column type="gchararray"/>
-    </columns>
   </object>
   <template class="Gcolor3Window" parent="GtkApplicationWindow">
     <property name="width_request">697</property>
@@ -35,28 +20,12 @@
         <property name="has_subtitle">False</property>
         <property name="show_close_button">True</property>
         <child>
-          <object class="GtkStackSwitcher" id="switcher">
+          <object class="GtkStackSwitcher">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="stack">stack</property>
           </object>
           <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkButton" id="button_delete">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="can_default">True</property>
-            <property name="has_default">True</property>
-            <property name="receives_default">False</property>
-            <property name="image">button_delete_image</property>
-            <property name="always_show_image">True</property>
-            <signal name="clicked" handler="gcolor3_window_delete_button_clicked" swapped="no"/>
-          </object>
-          <packing>
-            <property name="pack_type">end</property>
             <property name="position">1</property>
           </packing>
         </child>
@@ -98,22 +67,22 @@
         <property name="transition_type">slide-left-right</property>
         <signal name="notify::visible-child" handler="gcolor3_window_stack_changed" object="Gcolor3Window" swapped="no"/>
         <child>
-          <object class="GtkScrolledWindow" id="scroll">
+          <object class="GtkScrolledWindow">
+            <property name="width_request">550</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
+            <property name="halign">center</property>
             <property name="vexpand">True</property>
             <property name="shadow_type">in</property>
             <child>
-              <object class="GtkTreeView" id="tree">
+              <object class="GtkViewport">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="model">liststore</property>
-                <property name="search_column">2</property>
-                <property name="show_expanders">False</property>
-                <signal name="key-release-event" handler="gcolor3_window_tree_view_key_handler" object="Gcolor3Window" swapped="no"/>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection" id="selection">
-                    <signal name="changed" handler="gcolor3_window_selection_changed" object="Gcolor3Window" swapped="no"/>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkListBox" id="listbox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <signal name="selected-rows-changed" handler="gcolor3_window_selection_changed" object="Gcolor3Window" swapped="no"/>
                   </object>
                 </child>
               </object>

--- a/data/window.ui
+++ b/data/window.ui
@@ -28,41 +28,6 @@
     <property name="can_focus">False</property>
     <property name="border_width">6</property>
     <property name="window_position">center</property>
-    <child>
-      <object class="GtkStack" id="stack">
-        <property name="visible">True</property>
-        <property name="can_focus">False</property>
-        <property name="transition_type">slide-left-right</property>
-        <signal name="notify::visible-child" handler="gcolor3_window_stack_changed" object="Gcolor3Window" swapped="no"/>
-        <child>
-          <object class="GtkScrolledWindow" id="scroll">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="vexpand">True</property>
-            <property name="shadow_type">in</property>
-            <child>
-              <object class="GtkTreeView" id="tree">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="model">liststore</property>
-                <property name="search_column">2</property>
-                <property name="show_expanders">False</property>
-                <signal name="key-release-event" handler="gcolor3_window_tree_view_key_handler" object="Gcolor3Window" swapped="no"/>
-                <child internal-child="selection">
-                  <object class="GtkTreeSelection" id="selection">
-                    <signal name="changed" handler="gcolor3_window_selection_changed" object="Gcolor3Window" swapped="no"/>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="name">saved-colors</property>
-            <property name="title" translatable="yes">Saved colors</property>
-          </packing>
-        </child>
-      </object>
-    </child>
     <child type="titlebar">
       <object class="GtkHeaderBar" id="headerbar">
         <property name="visible">True</property>
@@ -122,6 +87,41 @@
           <packing>
             <property name="pack_type">end</property>
             <property name="position">3</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkStack" id="stack">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="transition_type">slide-left-right</property>
+        <signal name="notify::visible-child" handler="gcolor3_window_stack_changed" object="Gcolor3Window" swapped="no"/>
+        <child>
+          <object class="GtkScrolledWindow" id="scroll">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="vexpand">True</property>
+            <property name="shadow_type">in</property>
+            <child>
+              <object class="GtkTreeView" id="tree">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="model">liststore</property>
+                <property name="search_column">2</property>
+                <property name="show_expanders">False</property>
+                <signal name="key-release-event" handler="gcolor3_window_tree_view_key_handler" object="Gcolor3Window" swapped="no"/>
+                <child internal-child="selection">
+                  <object class="GtkTreeSelection" id="selection">
+                    <signal name="changed" handler="gcolor3_window_selection_changed" object="Gcolor3Window" swapped="no"/>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="name">saved-colors</property>
+            <property name="title" translatable="yes">Saved colors</property>
           </packing>
         </child>
       </object>

--- a/data/window.ui
+++ b/data/window.ui
@@ -45,37 +45,116 @@
           <object class="GtkStackSwitcher">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="stack">stack</property>
+            <property name="stack">page_stack</property>
           </object>
         </child>
       </object>
     </child>
     <child>
-      <object class="GtkStack" id="stack">
+      <object class="GtkStack" id="page_stack">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="transition_type">slide-left-right</property>
         <signal name="notify::visible-child" handler="gcolor3_window_stack_changed" object="Gcolor3Window" swapped="no"/>
         <child>
-          <object class="GtkScrolledWindow">
-            <property name="width_request">550</property>
+          <object class="GtkStack" id="list_stack">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="halign">center</property>
-            <property name="vexpand">True</property>
-            <property name="shadow_type">in</property>
+            <property name="can_focus">False</property>
+            <property name="transition_duration">100</property>
+            <property name="transition_type">crossfade</property>
             <child>
-              <object class="GtkViewport">
+              <object class="GtkScrolledWindow" id="scroll">
+                <property name="width_request">550</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can_focus">True</property>
+                <property name="halign">center</property>
+                <property name="vexpand">True</property>
+                <property name="shadow_type">in</property>
                 <child>
-                  <object class="GtkListBox" id="listbox">
+                  <object class="GtkViewport">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <signal name="selected-rows-changed" handler="gcolor3_window_selection_changed" object="Gcolor3Window" swapped="no"/>
+                    <child>
+                      <object class="GtkListBox" id="listbox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <signal name="selected-rows-changed" handler="gcolor3_window_selection_changed" object="Gcolor3Window" swapped="no"/>
+                      </object>
+                    </child>
                   </object>
                 </child>
               </object>
+              <packing>
+                <property name="name">page0</property>
+                <property name="title" translatable="yes">page0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="empty_placeholder">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="border_width">20</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">12</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">edit-clear-all-symbolic</property>
+                    <property name="icon_size">6</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label">Save a picked color to make it appear here</property>
+                    <property name="wrap">True</property>
+                    <property name="track_visited_links">False</property>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="pack_type">end</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label">You have no saved colors</property>
+                    <property name="track_visited_links">False</property>
+                    <attributes>
+                      <attribute name="scale" value="2"/>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="pack_type">end</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">page1</property>
+                <property name="title" translatable="yes">page1</property>
+                <property name="position">1</property>
+              </packing>
             </child>
           </object>
           <packing>

--- a/data/window.ui
+++ b/data/window.ui
@@ -2,7 +2,12 @@
 <!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
-  <object class="GtkImage" id="button_startup">
+  <object class="GtkImage" id="button_delete_image">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <property name="icon_name">edit-delete-symbolic</property>
+  </object>
+  <object class="GtkImage" id="button_save_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
     <property name="icon_name">document-save-symbolic</property>
@@ -75,15 +80,15 @@
           </packing>
         </child>
         <child>
-          <object class="GtkButton" id="button">
+          <object class="GtkButton" id="button_delete">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="can_default">True</property>
             <property name="has_default">True</property>
             <property name="receives_default">False</property>
-            <property name="action_name">win.save</property>
-            <property name="image">button_startup</property>
+            <property name="image">button_delete_image</property>
             <property name="always_show_image">True</property>
+            <signal name="clicked" handler="gcolor3_window_delete_button_clicked" swapped="no"/>
           </object>
           <packing>
             <property name="pack_type">end</property>
@@ -91,24 +96,31 @@
           </packing>
         </child>
         <child>
-          <object class="GtkRevealer" id="revealer">
+          <object class="GtkButton" id="button_save">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="transition_type">slide-left</property>
-            <property name="transition_duration">400</property>
-            <property name="reveal_child">True</property>
-            <child>
-              <object class="GtkEntry" id="entry">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="activates_default">True</property>
-                <property name="placeholder_text" translatable="yes">Color name...</property>
-              </object>
-            </child>
+            <property name="can_focus">True</property>
+            <property name="can_default">True</property>
+            <property name="has_default">True</property>
+            <property name="receives_default">False</property>
+            <property name="action_name">win.save</property>
+            <property name="image">button_save_image</property>
+            <property name="always_show_image">True</property>
           </object>
           <packing>
             <property name="pack_type">end</property>
             <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkEntry" id="entry">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="activates_default">True</property>
+            <property name="placeholder_text" translatable="yes">Color name...</property>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>

--- a/data/window.ui
+++ b/data/window.ui
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.1 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.16"/>
   <object class="GtkImage" id="button_startup">
@@ -42,6 +42,7 @@
                 <property name="model">liststore</property>
                 <property name="search_column">2</property>
                 <property name="show_expanders">False</property>
+                <signal name="key-release-event" handler="gcolor3_window_tree_view_key_handler" object="Gcolor3Window" swapped="no"/>
                 <child internal-child="selection">
                   <object class="GtkTreeSelection" id="selection">
                     <signal name="changed" handler="gcolor3_window_selection_changed" object="Gcolor3Window" swapped="no"/>

--- a/data/window.ui
+++ b/data/window.ui
@@ -33,8 +33,6 @@
           <object class="GtkButton" id="button_save">
             <property name="visible">True</property>
             <property name="can_focus">True</property>
-            <property name="can_default">True</property>
-            <property name="has_default">True</property>
             <property name="receives_default">False</property>
             <property name="image">button_save_image</property>
             <property name="always_show_image">True</property>
@@ -51,7 +49,8 @@
             <property name="can_focus">True</property>
             <property name="activates_default">True</property>
             <property name="placeholder_text" translatable="yes">Color name...</property>
-            <signal name="key-release-event" handler="gcolor3_window_picker_page_key_handler" object="Gcolor3Window" swapped="no"/>
+            <signal name="activate" handler="gcolor3_window_entry_activated" object="Gcolor3Window" swapped="no"/>
+            <signal name="key-press-event" handler="gcolor3_window_picker_page_key_handler" object="Gcolor3Window" swapped="no"/>
           </object>
           <packing>
             <property name="pack_type">end</property>

--- a/data/window.ui
+++ b/data/window.ui
@@ -14,20 +14,19 @@
     <property name="border_width">6</property>
     <property name="window_position">center</property>
     <child type="titlebar">
-      <object class="GtkHeaderBar" id="headerbar">
+      <object class="GtkHeaderBar">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="has_subtitle">False</property>
         <property name="show_close_button">True</property>
         <child>
-          <object class="GtkStackSwitcher">
+          <object class="GtkEntry" id="entry">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="stack">stack</property>
+            <property name="can_focus">True</property>
+            <property name="activates_default">True</property>
+            <property name="placeholder_text" translatable="yes">Color name...</property>
+            <signal name="activate" handler="gcolor3_window_entry_activated" object="Gcolor3Window" swapped="no"/>
+            <signal name="key-press-event" handler="gcolor3_window_picker_page_key_handler" object="Gcolor3Window" swapped="no"/>
           </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkButton" id="button_save">
@@ -39,23 +38,15 @@
             <signal name="clicked" handler="gcolor3_window_save_button_clicked" object="Gcolor3Window" swapped="no"/>
           </object>
           <packing>
-            <property name="pack_type">end</property>
-            <property name="position">2</property>
+            <property name="position">1</property>
           </packing>
         </child>
-        <child>
-          <object class="GtkEntry" id="entry">
+        <child type="title">
+          <object class="GtkStackSwitcher">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="activates_default">True</property>
-            <property name="placeholder_text" translatable="yes">Color name...</property>
-            <signal name="activate" handler="gcolor3_window_entry_activated" object="Gcolor3Window" swapped="no"/>
-            <signal name="key-press-event" handler="gcolor3_window_picker_page_key_handler" object="Gcolor3Window" swapped="no"/>
+            <property name="can_focus">False</property>
+            <property name="stack">stack</property>
           </object>
-          <packing>
-            <property name="pack_type">end</property>
-            <property name="position">3</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -2,9 +2,12 @@
 # Please keep this list sorted alphabetically.
 data/nl.hjdskes.gcolor3.desktop.in
 data/nl.hjdskes.gcolor3.appdata.xml.in
+data/color-row.ui
 data/menus.ui
 data/window.ui
 src/main.c
 src/gcolor3-application.c
+src/gcolor3-color-row.c
+src/gcolor3-color-selection.c
 src/gcolor3-color-store.c
 src/gcolor3-window.c

--- a/src/gcolor3-application.c
+++ b/src/gcolor3-application.c
@@ -95,7 +95,6 @@ gcolor3_application_init_accelerators (GtkApplication *application)
 	 * Enter the action name followed by the accelerator strings
 	 * and terminate the entry with a NULL-string.*/
 	static const gchar *const accelmap[] = {
-		"win.copy", "<Ctrl>c", NULL,
 		"win.save", "<Ctrl>s", NULL,
 		"win.delete", "<Shift>Delete", NULL,
 		"win.change-page", "F9", NULL,

--- a/src/gcolor3-application.c
+++ b/src/gcolor3-application.c
@@ -95,7 +95,6 @@ gcolor3_application_init_accelerators (GtkApplication *application)
 	 * Enter the action name followed by the accelerator strings
 	 * and terminate the entry with a NULL-string.*/
 	static const gchar *const accelmap[] = {
-		"win.save", "<Ctrl>s", NULL,
 		"win.change-page", "F9", NULL,
 		NULL /* Terminating NULL */
 	};

--- a/src/gcolor3-application.c
+++ b/src/gcolor3-application.c
@@ -96,7 +96,6 @@ gcolor3_application_init_accelerators (GtkApplication *application)
 	 * and terminate the entry with a NULL-string.*/
 	static const gchar *const accelmap[] = {
 		"win.save", "<Ctrl>s", NULL,
-		"win.delete", "<Shift>Delete", NULL,
 		"win.change-page", "F9", NULL,
 		NULL /* Terminating NULL */
 	};

--- a/src/gcolor3-color-item.c
+++ b/src/gcolor3-color-item.c
@@ -1,0 +1,139 @@
+/* Gcolor3ColorItem
+ *
+ * Copyright (C) 2018 Jente Hidskes
+ *
+ * Author: Jente Hidskes <hjdskes@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "config.h"
+
+#include "gcolor3-color-item.h"
+
+enum {
+      PROP_0,
+      PROP_KEY,
+      PROP_HEX,
+};
+
+struct _Gcolor3ColorItemPrivate {
+	gchar *key;
+	const gchar *hex;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE (Gcolor3ColorItem, gcolor3_color_item, G_TYPE_OBJECT)
+
+static void
+gcolor3_color_item_get_property (GObject    *object,
+				 guint       prop_id,
+				 GValue     *value,
+				 GParamSpec *pspec)
+{
+	Gcolor3ColorItemPrivate *priv;
+
+	priv = gcolor3_color_item_get_instance_private (GCOLOR3_COLOR_ITEM (object));
+
+	switch (prop_id) {
+	case PROP_KEY:
+		g_value_set_string (value, priv->key);
+		break;
+	case PROP_HEX:
+		g_value_set_string (value, priv->hex);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+static void
+gcolor3_color_item_set_property (GObject      *object,
+				 guint         prop_id,
+				 const GValue *value,
+				 GParamSpec   *pspec)
+{
+	Gcolor3ColorItemPrivate *priv;
+
+	priv = gcolor3_color_item_get_instance_private (GCOLOR3_COLOR_ITEM (object));
+
+	switch (prop_id) {
+	case PROP_KEY:
+		priv->key = g_value_dup_string (value);
+		break;
+	case PROP_HEX:
+		priv->hex = g_value_dup_string (value);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+static void
+gcolor3_color_item_finalize (GObject *object)
+{
+	Gcolor3ColorItemPrivate *priv;
+
+	priv = gcolor3_color_item_get_instance_private (GCOLOR3_COLOR_ITEM (object));
+
+	g_free (priv->key);
+
+	G_OBJECT_CLASS (gcolor3_color_item_parent_class)->finalize (object);
+}
+
+static void
+gcolor3_color_item_class_init (Gcolor3ColorItemClass *klass)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+
+	object_class->finalize = gcolor3_color_item_finalize;
+	object_class->get_property = gcolor3_color_item_get_property;
+	object_class->set_property = gcolor3_color_item_set_property;
+
+	g_object_class_install_property (object_class, PROP_KEY,
+					 g_param_spec_string ("key",
+							      "key",
+							      "Key of this row's color",
+							      "Black",
+							      G_PARAM_CONSTRUCT_ONLY |
+							      G_PARAM_READWRITE |
+							      G_PARAM_PRIVATE |
+							      G_PARAM_STATIC_STRINGS));
+
+	g_object_class_install_property (object_class, PROP_HEX,
+					 g_param_spec_string ("hex",
+							      "HexValue",
+							      "Hex value of this row's color",
+							      "#000000",
+							      G_PARAM_CONSTRUCT_ONLY |
+							      G_PARAM_READWRITE |
+							      G_PARAM_PRIVATE |
+							      G_PARAM_STATIC_STRINGS));
+}
+
+static void
+gcolor3_color_item_init (Gcolor3ColorItem *item)
+{
+}
+
+Gcolor3ColorItem *
+gcolor3_color_item_new (const gchar *key, const gchar *hex)
+{
+	g_return_val_if_fail (key != NULL, NULL);
+	g_return_val_if_fail (hex != NULL, NULL);
+
+	return g_object_new (GCOLOR3_TYPE_COLOR_ITEM, "key", key, "hex", hex, NULL);
+}

--- a/src/gcolor3-color-item.h
+++ b/src/gcolor3-color-item.h
@@ -1,0 +1,54 @@
+/* Gcolor3ColorItem
+ *
+ * Copyright (C) 2018 Jente Hidskes
+ *
+ * Author: Jente Hidskes <hjdskes@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef __GCOLOR3_COLOR_ITEM_H__
+#define __GCOLOR3_COLOR_ITEM_H__
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+typedef struct _Gcolor3ColorItem        Gcolor3ColorItem;
+typedef struct _Gcolor3ColorItemClass   Gcolor3ColorItemClass;
+typedef struct _Gcolor3ColorItemPrivate Gcolor3ColorItemPrivate;
+
+#define GCOLOR3_TYPE_COLOR_ITEM            (gcolor3_color_item_get_type ())
+#define GCOLOR3_COLOR_ITEM(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), GCOLOR3_TYPE_COLOR_ITEM, Gcolor3ColorItem))
+#define GCOLOR3_COLOR_ITEM_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  GCOLOR3_TYPE_COLOR_ITEM, Gcolor3ColorItemClass))
+#define GCOLOR3_IS_COLOR_ITEM(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), GCOLOR3_TYPE_COLOR_ITEM))
+#define GCOLOR3_IS_COLOR_ITEM_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  GCOLOR3_TYPE_COLOR_ITEM))
+#define GCOLOR3_COLOR_ITEM_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  GCOLOR3_TYPE_COLOR_ITEM, Gcolor3ColorItemClass))
+
+struct _Gcolor3ColorItem {
+	GObject base_instance;
+};
+
+struct _Gcolor3ColorItemClass {
+	GObjectClass parent_class;
+};
+
+GType             gcolor3_color_item_get_type (void) G_GNUC_CONST;
+
+Gcolor3ColorItem *gcolor3_color_item_new (const gchar *key, const gchar *hex);
+
+G_END_DECLS
+
+#endif /* __GCOLOR3_COLOR_ITEM_H__ */

--- a/src/gcolor3-color-row.c
+++ b/src/gcolor3-color-row.c
@@ -92,6 +92,16 @@ set_color_in_clipboard (const gchar *color)
 }
 
 static void
+gcolor3_color_row_copy_button_clicked (UNUSED GtkButton *button, gpointer user_data)
+{
+	Gcolor3ColorRowPrivate *priv;
+
+	priv = gcolor3_color_row_get_instance_private (GCOLOR3_COLOR_ROW (user_data));
+
+	set_color_in_clipboard (priv->hex);
+}
+
+static void
 gcolor3_color_row_delete_button_clicked (UNUSED GtkButton *button, gpointer user_data)
 {
 	g_signal_emit (GCOLOR3_COLOR_ROW (user_data), signals[SIGNAL_COLOR_REMOVED], 0);
@@ -256,6 +266,7 @@ gcolor3_color_row_class_init (Gcolor3ColorRowClass *gcolor3_color_row_class)
 	gtk_widget_class_bind_template_child_private (widget_class, Gcolor3ColorRow, label);
 	gtk_widget_class_bind_template_child_private (widget_class, Gcolor3ColorRow, entry);
 
+	gtk_widget_class_bind_template_callback (widget_class, gcolor3_color_row_copy_button_clicked);
 	gtk_widget_class_bind_template_callback (widget_class, gcolor3_color_row_delete_button_clicked);
 	gtk_widget_class_bind_template_callback (widget_class, gcolor3_color_row_entry_activated);
 }

--- a/src/gcolor3-color-row.c
+++ b/src/gcolor3-color-row.c
@@ -1,0 +1,283 @@
+/* Gcolor3ColorRow
+ *
+ * Copyright (C) 2018 Jente Hidskes
+ *
+ * Author: Jente Hidskes <hjdskes@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "config.h"
+
+#include <gtk/gtk.h>
+#include <glib/gprintf.h>
+#include <glib/gi18n.h>
+
+#include "gcolor3-color-row.h"
+
+#define I_(string) g_intern_static_string (string)
+#define THUMB_SIZE 24
+
+enum {
+      PROP_0,
+      PROP_KEY,
+      PROP_HEX,
+};
+
+enum {
+      SIGNAL_COLOR_REMOVED,
+      SIGNAL_COLOR_RENAMED,
+      SIGNAL_LAST,
+};
+
+static guint signals[SIGNAL_LAST];
+
+struct _Gcolor3ColorRowPrivate {
+	GtkWidget *image;
+	GtkWidget *label;
+	GtkWidget *entry;
+
+	gchar *key;
+	const gchar *hex;
+};
+
+G_DEFINE_TYPE_WITH_PRIVATE (Gcolor3ColorRow, gcolor3_color_row, GTK_TYPE_LIST_BOX_ROW)
+
+static void
+set_color_thumbnail (Gcolor3ColorRow *row)
+{
+	Gcolor3ColorRowPrivate *priv;
+	GdkPixbuf *pixbuf;
+	GdkRGBA color;
+	guint32 hex;
+
+	priv = gcolor3_color_row_get_instance_private (row);
+
+	if (!gdk_rgba_parse (&color, priv->hex)) {
+		g_warning (_("Could not parse color to display thumbnail\n"));
+		return;
+	}
+
+	hex = ((guint32) (color.red   * 255)) << 24 |
+	      ((guint32) (color.green * 255)) << 16 |
+	      ((guint32) (color.blue  * 255)) <<  8 |
+	      ((guint32) (color.alpha * 255));
+
+	// TODO: make circular?
+	pixbuf = gdk_pixbuf_new (GDK_COLORSPACE_RGB, FALSE, 8, THUMB_SIZE, THUMB_SIZE);
+	gdk_pixbuf_fill (pixbuf,  hex);
+	gtk_image_set_from_pixbuf (GTK_IMAGE (priv->image), pixbuf);
+	g_object_unref (pixbuf);
+}
+
+static void
+set_color_in_clipboard (const gchar *color)
+{
+	GtkClipboard *clipboard;
+
+	clipboard = gtk_clipboard_get (GDK_SELECTION_CLIPBOARD);
+	gtk_clipboard_set_text (clipboard, color, -1);
+}
+
+static void
+gcolor3_color_row_delete_button_clicked (UNUSED GtkButton *button, gpointer user_data)
+{
+	g_signal_emit (GCOLOR3_COLOR_ROW (user_data), signals[SIGNAL_COLOR_REMOVED], 0);
+}
+
+static void
+gcolor3_color_row_entry_activated (GtkEntry *entry, gpointer user_data)
+{
+	Gcolor3ColorRowPrivate *priv;
+	gchar *old_key;
+
+	priv = gcolor3_color_row_get_instance_private (GCOLOR3_COLOR_ROW (user_data));
+
+	old_key = g_strdup (priv->key);
+	priv->key = g_strdup (gtk_entry_get_text (entry));
+	g_signal_emit (GCOLOR3_COLOR_ROW (user_data), signals[SIGNAL_COLOR_RENAMED],
+		       0, old_key, priv->key);
+	g_free (old_key);
+}
+
+static gboolean
+gcolor3_color_row_key_press_event (GtkWidget   *row,
+				   GdkEventKey *event)
+{
+	Gcolor3ColorRowPrivate *priv;
+
+	if (event->type != GDK_KEY_PRESS) {
+		return GDK_EVENT_PROPAGATE;
+	}
+
+	priv = gcolor3_color_row_get_instance_private (GCOLOR3_COLOR_ROW (row));
+
+	switch (event->keyval) {
+	case GDK_KEY_c:
+		if ((event->state & GDK_CONTROL_MASK) != GDK_CONTROL_MASK) {
+			return GDK_EVENT_PROPAGATE;
+		}
+		set_color_in_clipboard (priv->hex);
+		return GDK_EVENT_STOP;
+	case GDK_KEY_Delete:
+		g_object_ref (row);
+		g_signal_emit (GCOLOR3_COLOR_ROW (row), signals[SIGNAL_COLOR_REMOVED], 0);
+		return GDK_EVENT_STOP;
+	default:
+		return GDK_EVENT_PROPAGATE;
+	}
+}
+
+static void
+gcolor3_color_row_set_property (GObject      *object,
+				guint         prop_id,
+				const GValue *value,
+				GParamSpec   *pspec)
+{
+	Gcolor3ColorRowPrivate *priv;
+
+	priv = gcolor3_color_row_get_instance_private (GCOLOR3_COLOR_ROW (object));
+
+	switch (prop_id) {
+	case PROP_KEY:
+		priv->key = g_value_dup_string (value);
+		break;
+	case PROP_HEX:
+		priv->hex = g_value_dup_string (value);
+		set_color_thumbnail (GCOLOR3_COLOR_ROW (object));
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+static void
+gcolor3_color_row_get_property (GObject    *object,
+				guint       prop_id,
+				GValue     *value,
+				GParamSpec *pspec)
+{
+	Gcolor3ColorRowPrivate *priv;
+
+	priv = gcolor3_color_row_get_instance_private (GCOLOR3_COLOR_ROW (object));
+
+	switch (prop_id) {
+	case PROP_KEY:
+		g_value_set_string (value, priv->key);
+		break;
+	case PROP_HEX:
+		g_value_set_string (value, priv->hex);
+		break;
+	default:
+		G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
+		break;
+	}
+}
+
+static void
+gcolor3_color_row_finalize (GObject *object)
+{
+	Gcolor3ColorRowPrivate *priv;
+
+	priv = gcolor3_color_row_get_instance_private (GCOLOR3_COLOR_ROW (object));
+
+	g_free (priv->key);
+
+	G_OBJECT_CLASS (gcolor3_color_row_parent_class)->finalize (object);
+}
+
+static void
+gcolor3_color_row_class_init (Gcolor3ColorRowClass *gcolor3_color_row_class)
+{
+	GObjectClass *object_class = G_OBJECT_CLASS (gcolor3_color_row_class);
+	GtkWidgetClass *widget_class = GTK_WIDGET_CLASS (gcolor3_color_row_class);
+
+	object_class->set_property = gcolor3_color_row_set_property;
+	object_class->get_property = gcolor3_color_row_get_property;
+	object_class->finalize = gcolor3_color_row_finalize;
+
+	widget_class->key_press_event = gcolor3_color_row_key_press_event;
+
+	signals[SIGNAL_COLOR_REMOVED] =
+		g_signal_new (I_("color-removed"),
+			      GCOLOR3_TYPE_COLOR_ROW,
+			      G_SIGNAL_RUN_LAST,
+			      0,
+			      NULL, NULL,
+			      NULL,
+			      G_TYPE_NONE, 0);
+
+	signals[SIGNAL_COLOR_RENAMED] =
+		g_signal_new (I_("color-renamed"),
+			      GCOLOR3_TYPE_COLOR_ROW,
+			      G_SIGNAL_RUN_LAST,
+			      0,
+			      NULL, NULL,
+			      NULL,
+			      G_TYPE_NONE, 2,
+			      G_TYPE_STRING, G_TYPE_STRING);
+
+	g_object_class_install_property (object_class, PROP_KEY,
+					 g_param_spec_string ("key",
+							      "key",
+							      "Key of this row's color",
+							      "Black",
+							      G_PARAM_CONSTRUCT_ONLY |
+							      G_PARAM_READWRITE |
+							      G_PARAM_PRIVATE |
+							      G_PARAM_STATIC_STRINGS));
+
+	g_object_class_install_property (object_class, PROP_HEX,
+					 g_param_spec_string ("hex",
+							      "HexValue",
+							      "Hex value of this row's color",
+							      "#000000",
+							      G_PARAM_CONSTRUCT_ONLY |
+							      G_PARAM_READWRITE |
+							      G_PARAM_PRIVATE |
+							      G_PARAM_STATIC_STRINGS));
+
+	gtk_widget_class_set_template_from_resource (widget_class, "/nl/hjdskes/gcolor3/color-row.ui");
+
+	gtk_widget_class_bind_template_child_private (widget_class, Gcolor3ColorRow, image);
+	gtk_widget_class_bind_template_child_private (widget_class, Gcolor3ColorRow, label);
+	gtk_widget_class_bind_template_child_private (widget_class, Gcolor3ColorRow, entry);
+
+	gtk_widget_class_bind_template_callback (widget_class, gcolor3_color_row_delete_button_clicked);
+	gtk_widget_class_bind_template_callback (widget_class, gcolor3_color_row_entry_activated);
+}
+
+static void
+gcolor3_color_row_init (Gcolor3ColorRow *color_row)
+{
+	Gcolor3ColorRowPrivate *priv;
+
+	priv = gcolor3_color_row_get_instance_private (color_row);
+
+	gtk_widget_init_template (GTK_WIDGET (color_row));
+
+	g_object_bind_property (color_row, "key", priv->entry, "text", G_BINDING_DEFAULT);
+	g_object_bind_property (color_row, "hex", priv->label, "label", G_BINDING_DEFAULT);
+}
+
+Gcolor3ColorRow *
+gcolor3_color_row_new (const gchar *key, const gchar *hex)
+{
+	g_return_val_if_fail (key != NULL, NULL);
+	g_return_val_if_fail (hex != NULL, NULL);
+
+	return g_object_new (GCOLOR3_TYPE_COLOR_ROW, "key", key, "hex", hex, NULL);
+}

--- a/src/gcolor3-color-row.h
+++ b/src/gcolor3-color-row.h
@@ -1,0 +1,54 @@
+/* Gcolor3ColorRow
+ *
+ * Copyright (C) 2018 Jente Hidskes
+ *
+ * Author: Jente Hidskes <hjdskes@gmail.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef __GCOLOR3_COLOR_ROW_H__
+#define __GCOLOR3_COLOR_ROW_H__
+
+#include <gtk/gtk.h>
+
+G_BEGIN_DECLS
+
+typedef struct _Gcolor3ColorRow        Gcolor3ColorRow;
+typedef struct _Gcolor3ColorRowClass   Gcolor3ColorRowClass;
+typedef struct _Gcolor3ColorRowPrivate Gcolor3ColorRowPrivate;
+
+#define GCOLOR3_TYPE_COLOR_ROW            (gcolor3_color_row_get_type ())
+#define GCOLOR3_COLOR_ROW(obj)            (G_TYPE_CHECK_INSTANCE_CAST((obj), GCOLOR3_TYPE_COLOR_ROW, Gcolor3ColorRow))
+#define GCOLOR3_COLOR_ROW_CLASS(klass)    (G_TYPE_CHECK_CLASS_CAST((klass),  GCOLOR3_TYPE_COLOR_ROW, Gcolor3ColorRowClass))
+#define GCOLOR3_IS_COLOR_ROW(obj)         (G_TYPE_CHECK_INSTANCE_TYPE((obj), GCOLOR3_TYPE_COLOR_ROW))
+#define GCOLOR3_IS_COLOR_ROW_CLASS(klass) (G_TYPE_CHECK_CLASS_TYPE((klass),  GCOLOR3_TYPE_COLOR_ROW))
+#define GCOLOR3_COLOR_ROW_GET_CLASS(obj)  (G_TYPE_INSTANCE_GET_CLASS((obj),  GCOLOR3_TYPE_COLOR_ROW, Gcolor3ColorRowClass))
+
+struct _Gcolor3ColorRow {
+	GtkListBoxRow base_instance;
+};
+
+struct _Gcolor3ColorRowClass {
+	GtkListBoxRowClass parent_class;
+};
+
+GType            gcolor3_color_row_get_type (void) G_GNUC_CONST;
+
+Gcolor3ColorRow *gcolor3_color_row_new (const gchar *key, const gchar *hex);
+
+G_END_DECLS
+
+#endif /* __GCOLOR3_COLOR_ROW_H__ */

--- a/src/gcolor3-color-store.c
+++ b/src/gcolor3-color-store.c
@@ -25,6 +25,7 @@
 #include <glib.h>
 #include <glib/gi18n.h>
 
+#include "gcolor3-color-item.h"
 #include "gcolor3-color-store.h"
 #include "gcolor3-marshalers.h"
 
@@ -97,8 +98,8 @@ static gpointer
 gcolor3_color_store_get_item (GListModel *list, guint position)
 {
 	Gcolor3ColorStorePrivate *priv;
+	Gcolor3ColorItem *item;
 	GError *error = NULL;
-	GVariant *res;
 	gsize n_items;
 	gchar **keys;
 	gchar *value;
@@ -125,10 +126,10 @@ gcolor3_color_store_get_item (GListModel *list, guint position)
 		return g_variant_new ("(ss)", "Black", "#000000");
 	}
 
-	res = g_variant_new ("(ss)", keys[position], value);
+	item = gcolor3_color_item_new (keys[position], value);
 	g_free (value);
 	g_strfreev (keys);
-	return res;
+	return item;
 }
 
 static void

--- a/src/gcolor3-color-store.c
+++ b/src/gcolor3-color-store.c
@@ -28,14 +28,6 @@
 #include "gcolor3-color-store.h"
 #include "gcolor3-marshalers.h"
 
-enum {
-	SIGNAL_COLOR_ADDED,
-	SIGNAL_COLOR_REMOVED,
-	SIGNAL_LAST,
-};
-
-static guint signals[SIGNAL_LAST];
-
 struct _Gcolor3ColorStorePrivate {
 	GKeyFile *colors;
 };
@@ -166,26 +158,6 @@ gcolor3_color_store_class_init (Gcolor3ColorStoreClass *gcolor3_color_store_clas
 	GObjectClass *object_class = G_OBJECT_CLASS (gcolor3_color_store_class);
 
 	object_class->dispose = gcolor3_color_store_dispose;
-
-	signals[SIGNAL_COLOR_ADDED] =
-		g_signal_new ("color-added", // FIXME: wrap in I_()?
-			      GCOLOR3_TYPE_COLOR_STORE,
-			      G_SIGNAL_RUN_LAST,
-			      0,
-			      NULL, NULL,
-			      _gcolor3_marshal_VOID__STRING_STRING,
-			      G_TYPE_NONE, 2,
-			      G_TYPE_STRING, G_TYPE_STRING);
-
-	signals[SIGNAL_COLOR_REMOVED] =
-		g_signal_new ("color-removed", // FIXME: wrap in I_()?
-			      GCOLOR3_TYPE_COLOR_STORE,
-			      G_SIGNAL_RUN_LAST,
-			      0,
-			      NULL, NULL,
-			      _gcolor3_marshal_VOID__STRING,
-			      G_TYPE_NONE, 1,
-			      G_TYPE_STRING);
 }
 
 static void
@@ -244,7 +216,6 @@ gcolor3_color_store_add_color (Gcolor3ColorStore *store, const gchar *key, const
 	}
 
 	g_key_file_set_string (priv->colors, "Colors", key, hex);
-	g_signal_emit (store, signals[SIGNAL_COLOR_ADDED], 0, key, hex);
 
 	if (!(keys = g_key_file_get_keys (priv->colors, "Colors", &length, &error))) {
 		g_warning (_("Cannot locate index of addition: %s. UI won't be updated\n"), error->message);
@@ -299,7 +270,6 @@ gcolor3_color_store_remove_color (Gcolor3ColorStore *store, const gchar *key)
 	}
 
 	g_list_model_items_changed (G_LIST_MODEL (store), i, 1, 0);
-	g_signal_emit (store, signals[SIGNAL_COLOR_REMOVED], 0, key);
 	return TRUE;
 }
 

--- a/src/gcolor3-color-store.c
+++ b/src/gcolor3-color-store.c
@@ -361,3 +361,9 @@ gcolor3_color_store_foreach (Gcolor3ColorStore           *store,
 	g_strfreev (keys);
 }
 
+gboolean
+gcolor3_color_store_empty (Gcolor3ColorStore *store)
+{
+	g_return_val_if_fail (GCOLOR3_IS_COLOR_STORE (store), TRUE);
+	return gcolor3_color_store_get_n_items (G_LIST_MODEL (store)) == 0;
+}

--- a/src/gcolor3-color-store.h
+++ b/src/gcolor3-color-store.h
@@ -69,6 +69,8 @@ void               gcolor3_color_store_foreach (Gcolor3ColorStore           *sto
 						Gcolor3ColorStoreForeachFunc func,
 						gpointer                     user_data);
 
+gboolean           gcolor3_color_store_empty (Gcolor3ColorStore *store);
+
 G_END_DECLS
 
 #endif /* __GCOLOR3_COLOR_STORE_H__ */

--- a/src/gcolor3-window.c
+++ b/src/gcolor3-window.c
@@ -26,6 +26,7 @@
 #include <glib/gprintf.h>
 #include <glib/gi18n.h>
 
+#include "gcolor3-color-item.h"
 #include "gcolor3-color-row.h"
 #include "gcolor3-color-selection.h"
 #include "gcolor3-color-store.h"
@@ -232,10 +233,9 @@ static GtkWidget *
 create_widget_func (gpointer item, gpointer user_data)
 {
 	Gcolor3ColorRow *row;
-	GVariant *tuple = (GVariant *) item;
 	gchar *key, *hex;
 
-	g_variant_get (tuple, "(ss)", &key, &hex);
+	g_object_get ((Gcolor3ColorItem *) item, "key", &key, "hex", &hex, NULL);
 	row = gcolor3_color_row_new (key, hex);
 	g_signal_connect (row, "color-removed",
 			  G_CALLBACK (gcolor3_window_color_row_deleted), user_data);

--- a/src/gcolor3-window.c
+++ b/src/gcolor3-window.c
@@ -38,7 +38,6 @@ enum {
 };
 
 struct _Gcolor3WindowPrivate {
-	GtkWidget *headerbar;
 	GtkWidget *button_save;
 	GtkWidget *entry;
 	GtkWidget *stack;
@@ -342,7 +341,6 @@ gcolor3_window_class_init (Gcolor3WindowClass *gcolor3_window_class)
 
 	gtk_widget_class_set_template_from_resource (widget_class, "/nl/hjdskes/gcolor3/window.ui");
 
-	gtk_widget_class_bind_template_child_private (widget_class, Gcolor3Window, headerbar);
 	gtk_widget_class_bind_template_child_private (widget_class, Gcolor3Window, button_save);
 	gtk_widget_class_bind_template_child_private (widget_class, Gcolor3Window, entry);
 	gtk_widget_class_bind_template_child_private (widget_class, Gcolor3Window, stack);
@@ -364,7 +362,6 @@ gcolor3_window_init (Gcolor3Window *window)
 	priv = gcolor3_window_get_instance_private (window);
 
 	gtk_widget_init_template (GTK_WIDGET (window));
-	gtk_header_bar_set_title (GTK_HEADER_BAR (priv->headerbar), g_get_application_name ());
 
 	/* Add the custom color selection widget. */
 	priv->picker = gcolor3_color_selection_new ();

--- a/src/gcolor3-window.c
+++ b/src/gcolor3-window.c
@@ -89,18 +89,27 @@ gcolor3_window_picker_page_key_handler (GtkWidget   *widget,
 
 	switch (event->keyval) {
 	case GDK_KEY_s:
-		if ((event->state & GDK_CONTROL_MASK) == GDK_CONTROL_MASK) {
-			save_color (priv->entry, priv->store, &priv->current);
+		if ((event->state & GDK_CONTROL_MASK) != GDK_CONTROL_MASK) {
+			return GDK_EVENT_PROPAGATE;
 		}
-		break;
-	case GDK_KEY_Return:
-		save_color (priv->entry, priv->store, &priv->current);
-		break;
+		/* Emulate a button click, to give the user visual feedback of
+		   the save action. */
+		g_signal_emit_by_name (priv->button_save, "activate");
+		return GDK_EVENT_STOP;
 	default:
-		break;
+		return GDK_EVENT_PROPAGATE;
 	}
+}
 
-	return GDK_EVENT_PROPAGATE;
+static void
+gcolor3_window_entry_activated (UNUSED GtkEntry *entry, gpointer user_data)
+{
+	Gcolor3WindowPrivate *priv;
+
+	priv = gcolor3_window_get_instance_private (GCOLOR3_WINDOW (user_data));
+	/* Emulate a button click, to give the user visual feedback of
+	   the save action. */
+	g_signal_emit_by_name (priv->button_save, "activate");
 }
 
 static void
@@ -342,8 +351,8 @@ gcolor3_window_class_init (Gcolor3WindowClass *gcolor3_window_class)
 	gtk_widget_class_bind_template_callback (widget_class, gcolor3_window_stack_changed);
 	gtk_widget_class_bind_template_callback (widget_class, gcolor3_window_picker_changed);
 	gtk_widget_class_bind_template_callback (widget_class, gcolor3_window_selection_changed);
-	gtk_widget_class_bind_template_callback (widget_class, gcolor3_window_tree_view_key_handler);
 	gtk_widget_class_bind_template_callback (widget_class, gcolor3_window_picker_page_key_handler);
+	gtk_widget_class_bind_template_callback (widget_class, gcolor3_window_entry_activated);
 	gtk_widget_class_bind_template_callback (widget_class, gcolor3_window_save_button_clicked);
 }
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,6 @@
 headers = [
   'gcolor3-application.h',
+  'gcolor3-color-row.h',
   'gcolor3-color-selection.h',
   'gcolor3-color-store.h',
   'gcolor3-hsv.h',
@@ -9,6 +10,7 @@ headers = [
 
 sources = [
   'gcolor3-application.c',
+  'gcolor3-color-row.c',
   'gcolor3-color-selection.c',
   'gcolor3-color-store.c',
   'gcolor3-hsv.c',

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,6 @@
 headers = [
   'gcolor3-application.h',
+  'gcolor3-color-item.h',
   'gcolor3-color-row.h',
   'gcolor3-color-selection.h',
   'gcolor3-color-store.h',
@@ -10,6 +11,7 @@ headers = [
 
 sources = [
   'gcolor3-application.c',
+  'gcolor3-color-item.c',
   'gcolor3-color-row.c',
   'gcolor3-color-selection.c',
   'gcolor3-color-store.c',


### PR DESCRIPTION
This PR removes the global actions for copying and deleting colors from the saved colors list. Instead, there is now a key handler callback registered on the tree view itself, so that only when that widget has focus the keyboard shortcuts trigger. I believe this is how it is supposed to be in the first place.

In the process, I also simplified the UI a bit to make it simpler to manage and calmer on the eyes.

@jtojnar, @dasnoopy, @diamondburned, @orschiro, can some of you please take this for a test to see if everything (still) works as expected?