### PR TITLE
Fix build with Clang

### DIFF
--- a/src/gcolor3-color-row.c
+++ b/src/gcolor3-color-row.c
@@ -85,7 +85,7 @@ set_color_thumbnail (Gcolor3ColorRow *row)
 	gtk_style_context_save (style_context);
 	gtk_style_context_get_property (style_context,
 					GTK_STYLE_PROPERTY_BORDER_RADIUS,
-					GTK_STATE_NORMAL,
+					GTK_STATE_FLAG_NORMAL,
 					&border_radius);
 	gtk_style_context_restore (style_context);
 


### PR DESCRIPTION
I'm trying to update the FreeBSD package of gcolor3 and the build fails with

```
../src/gcolor3-color-row.c:88:6: error: implicit conversion from enumeration type 'GtkStateType' to different enumeration type 'GtkStateFlags' [-Werror,-Wenum-conversion]
                                        GTK_STATE_NORMAL,
                                        ^~~~~~~~~~~~~~~~
```
Looks like Clang is more pedantic here than GCC.

I believe that we should use GTK_STATE_FLAG_NORMAL instead. Also see
https://developer.gnome.org/gtk3/stable/GtkStyleContext.html#gtk-style-context-get-property
https://developer.gnome.org/gtk3/stable/gtk3-Standard-Enumerations.html#GtkStateFlags