### PR TITLE
Fix build when gdk/gdkwayland.h is not available

### DIFF
--- a/src/gcolor3-color-selection.c
+++ b/src/gcolor3-color-selection.c
@@ -36,7 +36,10 @@
 
 #include <math.h>
 #include <string.h>
+#include <gdk/gdk.h>
+#ifdef GDK_WINDOWING_WAYLAND
 #include <gdk/gdkwayland.h>
+#endif
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 


### PR DESCRIPTION
When Gtk is compiled without Wayland support, gdkwayland.h is not available.

By default Wayland support is not enabled on FreeBSD in Gtk yet, so the build of gcolor3 would fail on systems using vanilla packages.