### PR TITLE
Fix the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Color Picker
 
 This README is only relevant for development resources and instructions. For a
 description of Color Picker, screenshots and installation instructions for end-users,
-please see the [website](https://hjdskes.nl/projects/gcolor3/).
+please see the [website](https://www.hjdskes.nl/projects/gcolor3/).
 
 Compile from source
 ------------

--- a/data/nl.hjdskes.gcolor3.appdata.xml.in
+++ b/data/nl.hjdskes.gcolor3.appdata.xml.in
@@ -36,7 +36,7 @@
       <caption>The list of saved colors</caption>
     </screenshot>
   </screenshots>
-  <url type="homepage">https://hjdskes.nl/projects/gcolor3/</url>
+  <url type="homepage">https://www.hjdskes.nl/projects/gcolor3/</url>
   <url type="bugtracker">https://gitlab.gnome.org/World/gcolor3/issues</url>
   <url type="help">https://gitlab.gnome.org/World/gcolor3/issues</url>
   <!-- Translators: please do NOT translate this. -->

--- a/meson.build
+++ b/meson.build
@@ -27,7 +27,7 @@ subdir('po')
 defines = [
   ['PACKAGE', meson.project_name()],
   ['PACKAGE_NAME', meson.project_name()],
-  ['PACKAGE_URL', 'https://hjdskes.nl/projects/gcolor3'],
+  ['PACKAGE_URL', 'https://www.hjdskes.nl/projects/gcolor3'],
   ['PACKAGE_VERSION', meson.project_version()],
   ['GETTEXT_PACKAGE', meson.project_name()],
   ['LOCALE_DIR', localedir],


### PR DESCRIPTION
The website seems to require www. now-- this commit fixes the URL in the readme, the about menu in the app, and the meson build script for good measure.